### PR TITLE
Move the call to `add_providers()` to the `plugins_loaded` hook

### DIFF
--- a/wat.tv.php
+++ b/wat.tv.php
@@ -27,7 +27,7 @@ class CFTP_Wattv {
 	 * Adds the oembed providers
 	 */
 	public function __construct() {
-		$this->add_providers();
+		add_action( 'plugins_loaded', array( $this, 'add_providers' ) );
 	}
 
 	public function add_providers() {


### PR DESCRIPTION
See https://core.trac.wordpress.org/ticket/28284 for background.
